### PR TITLE
Specializer specific config

### DIFF
--- a/ctree/c/nodes.py
+++ b/ctree/c/nodes.py
@@ -30,11 +30,9 @@ class CNode(CtreeNode):
 class CFile(CNode, File):
     """Represents a .c file."""
 
-    def __init__(self, name="generated", body=None, compile_command='CC', compile_flags='CFLAGS', config_target='jit'):
+    def __init__(self, name="generated", body=None, config_target='c'):
         super(CFile, self).__init__(name, body)
         self._ext = "c"
-        self.compile_command = compile_command
-        self.compile_flags = compile_flags
         self.config_target = config_target
 
     def get_bc_filename(self):
@@ -58,8 +56,8 @@ class CFile(CNode, File):
             c_file.write(program_text)
 
         # call clang to generate LLVM bitcode file
-        CC = ctree.CONFIG.get(self.config_target, self.compile_command)
-        CFLAGS = ctree.CONFIG.get(self.config_target, self.compile_flags)
+        CC = ctree.CONFIG.get(self.config_target, 'CC')
+        CFLAGS = ctree.CONFIG.get(self.config_target, 'CFLAGS')
         compile_cmd = "%s -emit-llvm %s -o %s -c %s" % (CC, CFLAGS, ll_bc_file, c_src_file)
         log.info("compilation command: %s", compile_cmd)
         subprocess.check_call(compile_cmd, shell=True)

--- a/ctree/defaults.cfg
+++ b/ctree/defaults.cfg
@@ -1,6 +1,16 @@
-[jit]
+[c]
 CC = clang
 CFLAGS = -O2
+PRESERVE_SRC_DIR = False
+
+[omp]
+CC = clang
+CFLAGS = -march=native -O2 -fopenmp -I/opt/intel/composerxe/include
+PRESERVE_SRC_DIR = False
+
+[opencl]
+CC = clang
+CFLAGS = -O2 -lOpenCL
 PRESERVE_SRC_DIR = False
 
 [log]

--- a/ctree/nodes.py
+++ b/ctree/nodes.py
@@ -191,9 +191,7 @@ class File(CommonNode):
     def __init__(self, name="generated", body=None):
         self.name = name
         self.body = body if body else []
-        self.compile_command = 'CC'
-        self.compile_flags = 'CFLAGS'
-        self.config_target = 'jit'
+        self.config_target = 'c'
 
     def codegen(self, *args):
         """Convert this substree into program text (a string)."""


### PR DESCRIPTION
Allows a specializer to define a .ctree.cfg target and command.  Useful when having multiple targets i.e. OCL vs OMP.  When creating the CFile, can specify which CC and CFLAGS should be used (including openmp files and using intel clang, vs normal clang and flags).

Example use cases:

``` python
if self.backend == StencilOmpTransformer:
    file = CFile("control", compile_command='OMP_CC', compile_flags='OMP_CFLAGS', config_target='stencil')
```

.ctree.cfg

```
[stencil]
OMP_CC = /usr/local/llvm-omp/bin/clang
OMP_CFLAGS = -march=native -O3 -fopenmp -I/opt/intel/composerxe/include
OCL_CC = clang
OCL_CFLAGS = -O3 -lOpenCL
```

@mbdriscoll I'm not convinced this is the best way to go about this.  We should probably add a try catch and have it default to jit, cc, cflags if the user hasn't create a .ctree.cfg.  Perhaps we should use methods instead of setting this information at construction time? (i.e. file.set_cc('OMP_CC'))
