### PR TITLE
Caching Command Line

### DIFF
--- a/ctree/defaults.cfg
+++ b/ctree/defaults.cfg
@@ -1,6 +1,7 @@
 [jit]
 PRESERVE_SRC_DIR = True
 COMPILE_PATH = ./compiled
+CACHE_ON = False
 
 [c]
 CC = clang

--- a/ctree/tools/runner.py
+++ b/ctree/tools/runner.py
@@ -5,6 +5,7 @@ basically copies all files and directories from a template.
 
 import sys
 import argparse
+import ctree
 from ctree.tools.generators import builder as Builder
 
 
@@ -24,6 +25,8 @@ def main(*args):
     )
     parser.add_argument('-p', '--port', help="/dev name to use for wattsup meter port")
     parser.add_argument('-v', '--verbose', help='show more debug than you like', action="store_true")
+    parser.add_argument('-dc', '--disable_caching', help='disable the persistent caching mechanism', action="store_true")
+    parser.add_argument('-ec', '--enable_caching', help='enable the persistent caching mechanism', action="store_true")
     args = parser.parse_args(args)
 
     if args.startproject:
@@ -32,14 +35,29 @@ def main(*args):
         print "create project specializer %s" % specializer_name
 
         builder = Builder.Builder("create", specializer_name, verbose=args.verbose)
-
         builder.build(None, None)
+        
     elif args.wattsupmeter:
         from ctree.metrics.watts_up_reader import WattsUpReader
 
         port = args.port if args.port else WattsUpReader.guess_port()
         meter = WattsUpReader(port_name=port)
         meter.interactive_mode()
+
+    elif args.enable_caching:
+        ctree.CONFIG.set("jit", "CACHE_ON", value="True")
+
+        with open(ctree.CFG_PATHS[-1], 'w') as configfile:
+            ctree.CONFIG.write(configfile)
+            configfile.close()
+
+    elif args.disable_caching:
+        ctree.CONFIG.set("jit", "CACHE_ON", value="False")
+
+        with open(ctree.CFG_PATHS[-1], 'w') as configfile:
+            ctree.CONFIG.write(configfile)
+            configfile.close()
+
     else:
         parser.print_usage()
 

--- a/ctree/tools/runner.py
+++ b/ctree/tools/runner.py
@@ -6,14 +6,17 @@ basically copies all files and directories from a template.
 import sys
 import argparse
 import ctree
+
 from ctree.tools.generators import builder as Builder
+from subprocess import call as shell
+
 
 
 __author__ = 'chick'
 
 
 def main(*args):
-    """run ctree utility stuff, currently only the project generator"""
+    '''run ctree utility stuff, currently only the project generator'''
 
     if sys.argv:
         args = sys.argv[1:]
@@ -25,8 +28,9 @@ def main(*args):
     )
     parser.add_argument('-p', '--port', help="/dev name to use for wattsup meter port")
     parser.add_argument('-v', '--verbose', help='show more debug than you like', action="store_true")
-    parser.add_argument('-dc', '--disable_caching', help='disable the persistent caching mechanism', action="store_true")
-    parser.add_argument('-ec', '--enable_caching', help='enable the persistent caching mechanism', action="store_true")
+    parser.add_argument('-dc', '--disable_caching', help='disable and delete the persistent cache', action="store_true")
+    parser.add_argument('-ec', '--enable_caching', help='enable the persistent cache', action="store_true")
+    parser.add_argument('-cc', '--clear_cache', help='clear the persistent cache', action="store_true")
     args = parser.parse_args(args)
 
     if args.startproject:
@@ -36,7 +40,7 @@ def main(*args):
 
         builder = Builder.Builder("create", specializer_name, verbose=args.verbose)
         builder.build(None, None)
-        
+
     elif args.wattsupmeter:
         from ctree.metrics.watts_up_reader import WattsUpReader
 
@@ -46,20 +50,46 @@ def main(*args):
 
     elif args.enable_caching:
         ctree.CONFIG.set("jit", "CACHE_ON", value="True")
-
-        with open(ctree.CFG_PATHS[-1], 'w') as configfile:
-            ctree.CONFIG.write(configfile)
-            configfile.close()
+        write_success = write_to_config()
+        if write_success: print("[SUCCESS] ctree caching enabled.")
 
     elif args.disable_caching:
         ctree.CONFIG.set("jit", "CACHE_ON", value="False")
+        write_success = write_to_config()
+        clear_cache()
+        if write_success: print("[SUCCESS] ctree caching disabled.")
 
-        with open(ctree.CFG_PATHS[-1], 'w') as configfile:
-            ctree.CONFIG.write(configfile)
-            configfile.close()
+    elif args.clear_cache:
+        clear_cache()
 
     else:
         parser.print_usage()
+
+
+def write_to_config():
+    '''
+    This method handles writing to the closest config file to the current
+    project, but does not write to the defaults.cfg file in ctree.
+    :return: return True if write is successful. False otherwise.
+    '''
+
+    if len(ctree.CFG_PATHS) > 0:
+        with open(ctree.CFG_PATHS[-1], 'w') as configfile:
+            ctree.CONFIG.write(configfile)
+            configfile.close()
+        return True
+    else:
+        print("[FAILURE] No config file detected. Please create a '.ctree.cfg' file in your project directory.")
+        return False
+
+
+def clear_cache():
+    '''
+    This method handles clearing the closest cache to the current project.
+    '''
+    path = ctree.CONFIG.get("jit", "COMPILE_PATH")
+    shell(["rm", "-rf", path])
+    print("[SUCCESS] ctree cache deleted from path: " + path)
 
 if __name__ == '__main__':
     main(sys.argv[1:])

--- a/ctree/tools/runner.py
+++ b/ctree/tools/runner.py
@@ -28,8 +28,8 @@ def main(*args):
     )
     parser.add_argument('-p', '--port', help="/dev name to use for wattsup meter port")
     parser.add_argument('-v', '--verbose', help='show more debug than you like', action="store_true")
-    parser.add_argument('-dc', '--disable_caching', help='disable and delete the persistent cache', action="store_true")
-    parser.add_argument('-ec', '--enable_caching', help='enable the persistent cache', action="store_true")
+    parser.add_argument('-dc', '--disable_cache', help='disable and delete the persistent cache', action="store_true")
+    parser.add_argument('-ec', '--enable_cache', help='enable the persistent cache', action="store_true")
     parser.add_argument('-cc', '--clear_cache', help='clear the persistent cache', action="store_true")
     args = parser.parse_args(args)
 


### PR DESCRIPTION
Caching is now valid via ctree command line, in your project directory.

`ctree -cc` (or `ctree --clear_cache`) will clear the closest cache to the project directory. 
`ctree -ec` (or `ctree --enable_cache`) will enable caching. 
`ctree -dc` (or `ctree --disable_cache`) will disable caching.